### PR TITLE
add operation get for long running operation output

### DIFF
--- a/cmd/offer/live.go
+++ b/cmd/offer/live.go
@@ -40,9 +40,9 @@ var (
 			}
 
 			opLocation, err := client.GoLiveWithOffer(ctx, partner.GoLiveParams{
-				NotificationEmails: publishOfferArgs.NotificationEmails,
-				OfferID:            publishOfferArgs.Offer,
-				PublisherID:        publishOfferArgs.Publisher,
+				NotificationEmails: goLiveOfferArgs.NotificationEmails,
+				OfferID:            goLiveOfferArgs.Offer,
+				PublisherID:        goLiveOfferArgs.Publisher,
 			})
 
 			if err != nil {

--- a/cmd/operation/get.go
+++ b/cmd/operation/get.go
@@ -1,0 +1,43 @@
+package operation
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/devigned/pub/pkg/xcobra"
+)
+
+func init() {
+	getCmd.Flags().StringVarP(&getOperationsArgs.OperationURI, "operation-uri", "o", "", "Operation URI from a long running activity. Like the URI returned from `pub offers live` or `pub offers publish`.")
+	_ = getCmd.MarkFlagRequired("operation-uri")
+	rootCmd.AddCommand(getCmd)
+}
+
+type (
+	// GetOperationsArgs are the arguments for `operations get` command
+	GetOperationsArgs struct {
+		OperationURI string
+	}
+)
+
+var (
+	getOperationsArgs GetOperationsArgs
+	getCmd            = &cobra.Command{
+		Use:   "get",
+		Short: "get an operation by URI fom a long running activity. Like the URI returned from `pub offers live` or `pub offers publish`.",
+		Run: xcobra.RunWithCtx(func(ctx context.Context, cmd *cobra.Command, args []string) {
+			client, err := getClient()
+			if err != nil {
+				xcobra.PrintfErrAndExit(1, "unable to create Cloud Partner Portal client: %v", err)
+			}
+
+			op, err := client.GetOperationByURI(ctx, getOperationsArgs.OperationURI)
+			if err != nil {
+				xcobra.PrintfErrAndExit(1, "unable to fetch operations: %v", err)
+			}
+
+			printOp(op)
+		}),
+	}
+)

--- a/pkg/partner/types.go
+++ b/pkg/partner/types.go
@@ -209,7 +209,7 @@ type (
 		Status             string          `json:"status,omitempty"`
 		Messages           []StatusMessage `json:"messages,omitempty"`
 		Steps              []StatusStep    `json:"steps,omitempty"`
-		PreviewLinks       []string        `json:"previewLinks,omitempty"`
+		PreviewLinks       []PreviewLink   `json:"previewLinks,omitempty"`
 		LiveLinks          []string        `json:"liveLinks,omitempty"`
 		NotificationEmails string          `json:"notificationEmails,omitempty"`
 	}
@@ -256,6 +256,12 @@ type (
 		ChangedTime       date.Time           `json:"changedTime,omitempty"`
 	}
 
+	// PreviewLink is the structure of a preview link in an OfferStatus
+	PreviewLink struct {
+		DisplayText string
+		URI         string
+	}
+
 	// OperationDetail is what is returned when querying for a single operation
 	OperationDetail struct {
 		PublishingVersion        *int            `json:"publishingVersion,omitempty"`
@@ -264,7 +270,7 @@ type (
 		Status                   string          `json:"status,omitempty"`
 		Messages                 []StatusMessage `json:"messages,omitempty"`
 		Steps                    []StatusStep    `json:"steps,omitempty"`
-		PreviewLinks             []string        `json:"previewLinks,omitempty"`
+		PreviewLinks             []PreviewLink   `json:"previewLinks,omitempty"`
 		LiveLinks                []string        `json:"liveLinks,omitempty"`
 		NotificationEmails       string          `json:"notificationEmails,omitempty"`
 	}


### PR DESCRIPTION
- fix bugs with go live not passing in the right info and attempting to deserialize json when none will be expected
- add a `pub operations get --operation-uri 'someuri'` which provides the ability to call `pub offers live` and `pub offers publish` and use the returned operation URI to track future status