### PR TITLE
Don't return an error if SKU already exists

### DIFF
--- a/cmd/sku/put.go
+++ b/cmd/sku/put.go
@@ -57,9 +57,8 @@ func newPutCommand(sl service.CommandServicer) (*cobra.Command, error) {
 			}
 
 			if offer.GetPlanByID(plan.ID) != nil {
-				err = fmt.Errorf("Plan '%v' already exists for offer '%v'", plan.ID, oArgs.Offer)
-				sl.GetPrinter().ErrPrintf("%v", err)
-				return err
+				warning := fmt.Sprintf("Plan '%v' already exists for offer '%v'", plan.ID, oArgs.Offer)
+				sl.GetPrinter().Print(warning)
 			}
 
 			offer.Definition.Plans = append(offer.Definition.Plans, plan)

--- a/cmd/sku/put.go
+++ b/cmd/sku/put.go
@@ -3,7 +3,6 @@ package sku
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 
 	"github.com/spf13/cobra"
@@ -54,11 +53,6 @@ func newPutCommand(sl service.CommandServicer) (*cobra.Command, error) {
 			if err != nil {
 				sl.GetPrinter().ErrPrintf("unable to get offer: %v", err)
 				return err
-			}
-
-			if offer.GetPlanByID(plan.ID) != nil {
-				warning := fmt.Sprintf("Plan '%v' already exists for offer '%v'", plan.ID, oArgs.Offer)
-				sl.GetPrinter().Print(warning)
 			}
 
 			offer.Definition.Plans = append(offer.Definition.Plans, plan)

--- a/cmd/sku/put_test.go
+++ b/cmd/sku/put_test.go
@@ -2,7 +2,6 @@ package sku
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,35 +52,6 @@ func TestPutCommand_FailOnGetOfferError(t *testing.T) {
 	cmd.SetArgs([]string{"-p", "foo", "-o", "bar", "-f", skuFileName})
 	assert.Error(t, cmd.Execute())
 	prtMock.AssertCalled(t, "ErrPrintf", "unable to get offer: %v", []interface{}{boomErr})
-}
-
-func TestPutCommand_FailOnPlanAlreadyExistsForOffer(t *testing.T) {
-	offer := test.NewMarketplaceVMOffer()
-	sku := offer.Definition.Plans[0]
-	dupeErr := fmt.Errorf("Plan '%v' already exists for offer '%v'", sku.ID, offer.ID)
-	_, skuFileName, del := test.NewTmpSKUFile(t, "sku", sku.ID)
-	defer del()
-
-	svcMock := new(test.CloudPartnerServiceMock)
-	svcMock.
-		On("GetOffer", mock.Anything, partner.ShowOfferParams{
-			PublisherID: offer.PublisherID,
-			OfferID:     offer.ID,
-		}).
-		Return(offer, nil)
-
-	prtMock := new(test.PrinterMock)
-	prtMock.On("ErrPrintf", "%v", []interface{}{dupeErr}).Return(nil)
-
-	rm := new(test.RegistryMock)
-	rm.On("GetCloudPartnerService").Return(svcMock, nil)
-	rm.On("GetPrinter").Return(prtMock)
-
-	cmd, err := test.QuietCommand(newPutCommand(rm))
-	require.NoError(t, err)
-	cmd.SetArgs([]string{"-p", offer.PublisherID, "-o", offer.ID, "-f", skuFileName})
-	assert.Error(t, cmd.Execute())
-	prtMock.AssertCalled(t, "ErrPrintf", "%v", []interface{}{dupeErr})
 }
 
 func TestPutCommand_FailOnPutOfferError(t *testing.T) {


### PR DESCRIPTION
The PUT call is idempotent, we should not return an error if the SKU already exists.