### PR TITLE
Overwrite SKU if it exists

### DIFF
--- a/cmd/sku/put.go
+++ b/cmd/sku/put.go
@@ -55,7 +55,7 @@ func newPutCommand(sl service.CommandServicer) (*cobra.Command, error) {
 				return err
 			}
 
-			offer.Definition.Plans = append(offer.Definition.Plans, plan)
+			offer.SetPlanByID(plan)
 
 			updatedOffer, err := client.PutOffer(ctx, offer)
 			if err != nil {

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -61,9 +61,10 @@ func NewTmpOfferFile(t *testing.T, prefix string) (string, func()) {
 	}
 }
 
-func NewTmpSKUFile(t *testing.T, prefix, Id string) (plan partner.Plan, filename string, deleteFunc func()) {
+func NewTmpSKUFile(t *testing.T, prefix, Id, summary string) (plan partner.Plan, filename string, deleteFunc func()) {
 	sku := NewMarketplaceVMOffer().Definition.Plans[0]
 	sku.ID = Id
+	sku.PlanVirtualMachineDetail.SKUSummary = summary
 
 	f, err := ioutil.TempFile("", prefix)
 	require.NoError(t, err)

--- a/pkg/partner/types.go
+++ b/pkg/partner/types.go
@@ -307,6 +307,17 @@ func (o *Offer) GetPlanByID(planID string) *Plan {
 	return nil
 }
 
+// SetPlanByID will update the plan in the offer if it exists or append it
+func (o *Offer) SetPlanByID(plan Plan) {
+	for i, p := range o.Definition.Plans {
+		if p.ID == plan.ID {
+			o.Definition.Plans[i] = plan
+			return
+		}
+	}
+	o.Definition.Plans = append(o.Definition.Plans, plan)
+}
+
 // GetVMImages returns a map of VirtualMachineImages by version
 func (p *Plan) GetVMImages() map[string]VirtualMachineImage {
 	switch {


### PR DESCRIPTION
If a SKU exists, we should update it instead of appending a new entry. Otherwise, we can get in a situation where the SKU appears twice.
