### PR TITLE
Increase HTTP timeout to 5 minutes

### DIFF
--- a/pkg/partner/client.go
+++ b/pkg/partner/client.go
@@ -605,7 +605,7 @@ func (c *Client) getHTTPClient() *http.Client {
 	}
 
 	return &http.Client{
-		Timeout: 60 * time.Second,
+		Timeout: 5 * 60 * time.Second,
 	}
 }
 


### PR DESCRIPTION
We have observed multiple flakes recently failing with:

`unable to get offer: Get "https://cloudpartner.azure.com/api/publishers/abc/offers/abcd?api-version=2017-10-31": context deadline exceeded (Client.Timeout exceeded while awaiting headers)`

Increasing the timeout from 1 minute to 5 minutes.
