### PR TITLE
Add categoryMap to offer types

### DIFF
--- a/pkg/partner/types.go
+++ b/pkg/partner/types.go
@@ -40,32 +40,33 @@ type (
 
 	// MarketplaceDetail are the marketing and contact information for a marketplace offering
 	MarketplaceDetail struct {
-		Title                       string   `json:"microsoft-azure-marketplace.title,omitempty"`
-		Summary                     string   `json:"microsoft-azure-marketplace.summary,omitempty"`
-		LongSummary                 string   `json:"microsoft-azure-marketplace.longSummary,omitempty"`
-		Description                 string   `json:"microsoft-azure-marketplace.description,omitempty"`
-		CSPOfferOptIn               *bool    `json:"microsoft-azure-marketplace.cspOfferOptIn,omitempty"`
-		OfferMarketingURLIdentifier string   `json:"microsoft-azure-marketplace.offerMarketingUrlIdentifier,omitempty"`
-		AllowedSubscriptions        []string `json:"microsoft-azure-marketplace.allowedSubscriptions,omitempty"`
-		UsefulLinks                 []string `json:"microsoft-azure-marketplace.usefulLinks,omitempty"`
-		Categories                  []string `json:"microsoft-azure-marketplace.categories,omitempty"`
-		SmallLogo                   string   `json:"microsoft-azure-marketplace.smallLogo,omitempty"`
-		MediumLogo                  string   `json:"microsoft-azure-marketplace.mediumLogo,omitempty"`
-		WideLogo                    string   `json:"microsoft-azure-marketplace.wideLogo,omitempty"`
-		ScreenShots                 []string `json:"microsoft-azure-marketplace.screenshots,omitempty"`
-		Videos                      []string `json:"microsoft-azure-marketplace.videos,omitempty"`
-		LeadDestination             string   `json:"microsoft-azure-marketplace.leadDestination,omitempty"`
-		PrivacyURL                  string   `json:"microsoft-azure-marketplace.privacyURL,omitempty"`
-		UseEnterpriseContract       *bool    `json:"microsoft-azure-marketplace.useEnterpriseContract,omitempty"`
-		TermsOfUse                  string   `json:"microsoft-azure-marketplace.termsOfUse,omitempty"`
-		EngineeringContactName      string   `json:"microsoft-azure-marketplace.engineeringContactName,omitempty"`
-		EngineeringContactEmail     string   `json:"microsoft-azure-marketplace.engineeringContactEmail,omitempty"`
-		EngineeringContactPhone     string   `json:"microsoft-azure-marketplace.engineeringContactPhone,omitempty"`
-		SupportContactName          string   `json:"microsoft-azure-marketplace.supportContactName,omitempty"`
-		SupportContactEmail         string   `json:"microsoft-azure-marketplace.supportContactEmail,omitempty"`
-		SupportContactPhone         string   `json:"microsoft-azure-marketplace.supportContactPhone,omitempty"`
-		PublicAzureSupportURL       string   `json:"microsoft-azure-marketplace.publicAzureSupportUrl,omitempty"`
-		FairfaxSupportURL           string   `json:"microsoft-azure-marketplace.fairfaxSupportUrl,omitempty"`
+		Title                       string                   `json:"microsoft-azure-marketplace.title,omitempty"`
+		Summary                     string                   `json:"microsoft-azure-marketplace.summary,omitempty"`
+		LongSummary                 string                   `json:"microsoft-azure-marketplace.longSummary,omitempty"`
+		Description                 string                   `json:"microsoft-azure-marketplace.description,omitempty"`
+		CSPOfferOptIn               *bool                    `json:"microsoft-azure-marketplace.cspOfferOptIn,omitempty"`
+		OfferMarketingURLIdentifier string                   `json:"microsoft-azure-marketplace.offerMarketingUrlIdentifier,omitempty"`
+		AllowedSubscriptions        []string                 `json:"microsoft-azure-marketplace.allowedSubscriptions,omitempty"`
+		UsefulLinks                 []string                 `json:"microsoft-azure-marketplace.usefulLinks,omitempty"`
+		Categories                  []string                 `json:"microsoft-azure-marketplace.categories,omitempty"`
+		CategoryMap                 []map[string]interface{} `json:"microsoft-azure-marketplace.categoryMap,omitempty"`
+		SmallLogo                   string                   `json:"microsoft-azure-marketplace.smallLogo,omitempty"`
+		MediumLogo                  string                   `json:"microsoft-azure-marketplace.mediumLogo,omitempty"`
+		WideLogo                    string                   `json:"microsoft-azure-marketplace.wideLogo,omitempty"`
+		ScreenShots                 []string                 `json:"microsoft-azure-marketplace.screenshots,omitempty"`
+		Videos                      []string                 `json:"microsoft-azure-marketplace.videos,omitempty"`
+		LeadDestination             string                   `json:"microsoft-azure-marketplace.leadDestination,omitempty"`
+		PrivacyURL                  string                   `json:"microsoft-azure-marketplace.privacyURL,omitempty"`
+		UseEnterpriseContract       *bool                    `json:"microsoft-azure-marketplace.useEnterpriseContract,omitempty"`
+		TermsOfUse                  string                   `json:"microsoft-azure-marketplace.termsOfUse,omitempty"`
+		EngineeringContactName      string                   `json:"microsoft-azure-marketplace.engineeringContactName,omitempty"`
+		EngineeringContactEmail     string                   `json:"microsoft-azure-marketplace.engineeringContactEmail,omitempty"`
+		EngineeringContactPhone     string                   `json:"microsoft-azure-marketplace.engineeringContactPhone,omitempty"`
+		SupportContactName          string                   `json:"microsoft-azure-marketplace.supportContactName,omitempty"`
+		SupportContactEmail         string                   `json:"microsoft-azure-marketplace.supportContactEmail,omitempty"`
+		SupportContactPhone         string                   `json:"microsoft-azure-marketplace.supportContactPhone,omitempty"`
+		PublicAzureSupportURL       string                   `json:"microsoft-azure-marketplace.publicAzureSupportUrl,omitempty"`
+		FairfaxSupportURL           string                   `json:"microsoft-azure-marketplace.fairfaxSupportUrl,omitempty"`
 	}
 
 	// VirtualMachinePricing is the marketplace VM pricing details
@@ -141,6 +142,7 @@ type (
 		UsefulLinksFairfax         []string                       `json:"microsoft-azure-corevm.usefulLinksFairfax,omitempty"`
 		UsefulLinksMooncake        []string                       `json:"microsoft-azure-corevm.usefulLinksMooncake,omitempty"`
 		Categories                 []string                       `json:"microsoft-azure-corevm.categories,omitempty"`
+		CategoryMap                []map[string]interface{}       `json:"microsoft-azure-corevm.categoryMap,omitempty"`
 		SmallLogo                  string                         `json:"microsoft-azure-corevm.smallLogo,omitempty"`
 		MediumLogo                 string                         `json:"microsoft-azure-corevm.mediumLogo,omitempty"`
 		LargeLogo                  string                         `json:"microsoft-azure-corevm.largeLogo,omitempty"`

--- a/pkg/partner/types_test.go
+++ b/pkg/partner/types_test.go
@@ -36,6 +36,14 @@ const (
       "microsoft-azure-marketplace.categories": [
         "devService"
       ],
+      "microsoft-azure-marketplace.categoryMap": [
+          {
+              "categoryL1": "compute",
+              "categoryL2-compute": [
+                  "operating-systems"
+              ]
+          }
+      ],
       "microsoft-azure-marketplace.smallLogo": "smallLogo",
       "microsoft-azure-marketplace.mediumLogo": "mediumLogo",
       "microsoft-azure-marketplace.wideLogo": "wideLogo",
@@ -271,23 +279,29 @@ func TestOffer_JSON(t *testing.T) {
 					AllowedSubscriptions:        []string{"4145cbfe-cd94-439d-aa3c-1ec6c7e53074"},
 					UsefulLinks:                 nil,
 					Categories:                  []string{"devService"},
-					SmallLogo:                   "smallLogo",
-					MediumLogo:                  "mediumLogo",
-					WideLogo:                    "wideLogo",
-					ScreenShots:                 nil,
-					Videos:                      nil,
-					LeadDestination:             "None",
-					PrivacyURL:                  "privacyURL",
-					UseEnterpriseContract:       to.BoolPtr(false),
-					TermsOfUse:                  "termsOfUse",
-					EngineeringContactName:      "engineeringContactName",
-					EngineeringContactEmail:     "engineeringContactEmail",
-					EngineeringContactPhone:     "engineeringContactPhone",
-					SupportContactName:          "supportContactName",
-					SupportContactEmail:         "supportContactEmail",
-					SupportContactPhone:         "supportContactPhone",
-					PublicAzureSupportURL:       "publicAzureSupportUrl",
-					FairfaxSupportURL:           "fairfaxSupportUrl",
+					CategoryMap: []map[string]interface{}{
+						{
+							"categoryL1":         "compute",
+							"categoryL2-compute": []interface{}{"operating-systems"},
+						},
+					},
+					SmallLogo:               "smallLogo",
+					MediumLogo:              "mediumLogo",
+					WideLogo:                "wideLogo",
+					ScreenShots:             nil,
+					Videos:                  nil,
+					LeadDestination:         "None",
+					PrivacyURL:              "privacyURL",
+					UseEnterpriseContract:   to.BoolPtr(false),
+					TermsOfUse:              "termsOfUse",
+					EngineeringContactName:  "engineeringContactName",
+					EngineeringContactEmail: "engineeringContactEmail",
+					EngineeringContactPhone: "engineeringContactPhone",
+					SupportContactName:      "supportContactName",
+					SupportContactEmail:     "supportContactEmail",
+					SupportContactPhone:     "supportContactPhone",
+					PublicAzureSupportURL:   "publicAzureSupportUrl",
+					FairfaxSupportURL:       "fairfaxSupportUrl",
 				},
 			},
 			Plans: []partner.Plan{


### PR DESCRIPTION
Had to use a type `[]map[string]interface{}` because this is what an actual real-life example of categoryMap looks like:

```
"microsoft-azure-corevm.categoryMap": [
                    {
                        "categoryL1": "compute",
                        "categoryL2-compute": [
                            "operating-systems"
                        ]
                    }
                ],
```
