### PR TITLE
Add `CoreMultiplier` struct

### DIFF
--- a/pkg/partner/types.go
+++ b/pkg/partner/types.go
@@ -69,10 +69,17 @@ type (
 		FairfaxSupportURL           string                   `json:"microsoft-azure-marketplace.fairfaxSupportUrl,omitempty"`
 	}
 
+	// CoreMultiplier specifies one price in USD for their SKU and all other prices are automatically generated
+	CoreMultiplier struct {
+		Currency string   `json:"currency,omitempty"`
+		Single   *float32 `json:"single,omitempty"`
+	}
+
 	// VirtualMachinePricing is the marketplace VM pricing details
 	VirtualMachinePricing struct {
-		IsBringYourOwnLicense     *bool `json:"isByol,omitempty"`
-		FreeTrialDurationInMonths *int  `json:"freeTrialDurationInMonths,omitempty"`
+		IsBringYourOwnLicense     *bool           `json:"isByol,omitempty"`
+		FreeTrialDurationInMonths *int            `json:"freeTrialDurationInMonths,omitempty"`
+		CoreMultiplier            *CoreMultiplier `json:"coreMultiplier,omitempty"`
 	}
 
 	// PlanVirtualMachineDetail contains the details for virtual machine SKUs
@@ -88,6 +95,7 @@ type (
 		OperatingSystemFamily          string                         `json:"microsoft-azure-virtualmachines.operatingSystemFamily,omitempty"`
 		OSType                         string                         `json:"microsoft-azure-virtualmachines.osType,omitempty"`
 		OperatingSystem                string                         `json:"microsoft-azure-virtualmachines.operatingSystem,omitempty"`
+		OperationSystem                string                         `json:"microsoft-azure-virtualmachines.operationSystem,omitempty"`
 		RecommendedVirtualMachineSizes []string                       `json:"microsoft-azure-virtualmachines.recommendedVMSizes,omitempty"`
 		VMImages                       map[string]VirtualMachineImage `json:"microsoft-azure-virtualmachines.vmImages,omitempty"`
 	}

--- a/pkg/partner/types_test.go
+++ b/pkg/partner/types_test.go
@@ -217,13 +217,22 @@ const (
         "microsoft-azure-virtualmachines.supportsAcceleratedNetworking": false,
         "virtualMachinePricing": {
           "isByol": true,
-          "freeTrialDurationInMonths": 0
+          "freeTrialDurationInMonths": 0,
+          "coreMultiplier": {
+		     "currency": "USD",
+		     "single": 0.0
+		   }
         },
         "virtualMachinePricingV2": {
           "isByol": true,
-          "freeTrialDurationInMonths": 0
+          "freeTrialDurationInMonths": 0,
+          "coreMultiplier": {
+			"currency": "USD",
+			"single": 0.0
+		  }
         },
         "microsoft-azure-virtualmachines.operatingSystemFamily": "Linux",
+        "microsoft-azure-virtualmachines.operationSystem": "Bionic",
         "microsoft-azure-virtualmachines.osType": "Ubuntu",
         "microsoft-azure-virtualmachines.recommendedVMSizes": [
           "ds2-standard-v2",
@@ -317,14 +326,23 @@ func TestOffer_JSON(t *testing.T) {
 						VirtualMachinePricing: &partner.VirtualMachinePricing{
 							IsBringYourOwnLicense:     to.BoolPtr(true),
 							FreeTrialDurationInMonths: to.IntPtr(0),
+							CoreMultiplier: &partner.CoreMultiplier{
+								Currency: "USD",
+								Single:   to.Float32Ptr(0.0),
+							},
 						},
 						VirtualMachinePricingV2: &partner.VirtualMachinePricing{
 							IsBringYourOwnLicense:     to.BoolPtr(true),
 							FreeTrialDurationInMonths: to.IntPtr(0),
+							CoreMultiplier: &partner.CoreMultiplier{
+								Currency: "USD",
+								Single:   to.Float32Ptr(0.0),
+							},
 						},
 						OperatingSystemFamily: "Linux",
 						OSType:                "Ubuntu",
 						OperatingSystem:       "",
+						OperationSystem:       "Bionic",
 						RecommendedVirtualMachineSizes: []string{
 							"ds2-standard-v2",
 							"d2-standard-v3",
@@ -357,5 +375,5 @@ func TestOffer_JSON(t *testing.T) {
 		Etag:        "W/\"datetime'2019-10-30T22%3A03%3A51.6562051Z'\"",
 	}
 
-	assert.Equal(t, actualOffer, expectedOffer)
+	assert.Equal(t, expectedOffer, actualOffer)
 }


### PR DESCRIPTION
- Enables users to set a per-core pricing using a single parameter for
PAYG selection; See https://docs.microsoft.com/en-us/azure/marketplace/cloud-partner-portal-api-setting-price#per-core-pricing

Authored-by: Fei Yang <yangfe@vmware.com>