### PR TITLE
Remove client request

### DIFF
--- a/pkg/partner/client.go
+++ b/pkg/partner/client.go
@@ -172,7 +172,6 @@ func New(apiVersion string, opts ...ClientOption) (*Client, error) {
 			if err != nil {
 				return nil, err
 			}
-			settings.Values[auth.Resource] = CloudPartnerResource
 
 			a, err = settings.GetAuthorizer()
 			if err != nil {


### PR DESCRIPTION
fixes the error:

```
unable to fetch the offer: azure.BearerAuthorizer#WithAuthorization: 
Failed to refresh the *** for request to https://cloudpartner.azure.com
/api/publishers/*****: StatusCode=400 -- Original Error: adal: Refresh 
request failed. Status Code = '400'. Response body: 
{"error":"invalid_request","error_description":"AADSTS700020: 
Application ID https://cloudpartner.azure.com is a reserverd identifier 
and should be removed on the application....
```