### PR TITLE
add error printing on the inner http client during debug

### DIFF
--- a/pkg/partner/client.go
+++ b/pkg/partner/client.go
@@ -136,6 +136,7 @@ var (
 
 			res, err := next(ctx, req)
 			if err != nil {
+				printErrLine("+%v\n", err)
 				return res, err
 			}
 


### PR DESCRIPTION
This PR adds error printing for the inner HTTP client result during debugging. This is just to make sure all error paths have some output during debug.

@mboersma